### PR TITLE
Allow traversal of Entity

### DIFF
--- a/src/AasxServerStandardBib/AasxHttpContextHelper.cs
+++ b/src/AasxServerStandardBib/AasxHttpContextHelper.cs
@@ -445,6 +445,14 @@ namespace AasxRestServerLibrary
                             if (r != null)
                                 return r;
                         }
+
+                        var xent = smw.submodelElement as AdminShell.Entity;
+                        if (xent != null)
+                        {
+                            var r = FindSubmodelElement(xsmc, xent.statements, elemids, elemNdx + 1);
+                            if (r != null)
+                                return r;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Next to SubmodelElementCollection and Operation, the statements of an Entity should be able to be traversed when finding specific sub-entities

See #73 