### PR TITLE
Upgrade most packages to net8.0 compatibility 

### DIFF
--- a/src/AasSecurityTests/AasSecurityTests.csproj
+++ b/src/AasSecurityTests/AasSecurityTests.csproj
@@ -21,7 +21,10 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="xunit" Version="2.8.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AasSecurityTests/AasSecurityTests.csproj
+++ b/src/AasSecurityTests/AasSecurityTests.csproj
@@ -18,7 +18,7 @@
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="JetBrains.Annotations" Version="2024.2.0-eap1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
         <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="xunit" Version="2.8.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">

--- a/src/AasxCsharpLibrary/AasxCsharpLibrary.csproj
+++ b/src/AasxCsharpLibrary/AasxCsharpLibrary.csproj
@@ -44,8 +44,8 @@
         <PackageReference Include="Namotion.Reflection" Version="2.1.1"/>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
         <PackageReference Include="NJsonSchema" Version="10.8.0"/>
-        <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0"/>
-        <PackageReference Include="System.IO.Packaging" Version="6.0.0"/>
+        <PackageReference Include="System.ComponentModel.Composition" Version="8.0.0" />
+        <PackageReference Include="System.IO.Packaging" Version="8.0.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\AasCore.Aas3_0\AasCore.Aas3_0.csproj"/>

--- a/src/AasxCsharpLibrary/AasxCsharpLibrary.csproj
+++ b/src/AasxCsharpLibrary/AasxCsharpLibrary.csproj
@@ -41,9 +41,9 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" Version="2022.1.0"/>
-        <PackageReference Include="Namotion.Reflection" Version="2.1.1"/>
+        <PackageReference Include="Namotion.Reflection" Version="3.1.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
-        <PackageReference Include="NJsonSchema" Version="10.8.0"/>
+        <PackageReference Include="NJsonSchema" Version="11.0.1" />
         <PackageReference Include="System.ComponentModel.Composition" Version="8.0.0" />
         <PackageReference Include="System.IO.Packaging" Version="8.0.0" />
     </ItemGroup>

--- a/src/AasxServerAspNetCore/AasxServerAspNetCore.csproj
+++ b/src/AasxServerAspNetCore/AasxServerAspNetCore.csproj
@@ -13,8 +13,8 @@
 
     <ItemGroup>
         <PackageReference Include="HotChocolate.AspNetCore" Version="13.5.1"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
-        <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0"/>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AasxServerAspNetCore/AasxServerAspNetCore.csproj
+++ b/src/AasxServerAspNetCore/AasxServerAspNetCore.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="HotChocolate.AspNetCore" Version="13.5.1"/>
+        <PackageReference Include="HotChocolate.AspNetCore" Version="13.9.6" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
         <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.2" />
     </ItemGroup>

--- a/src/AasxServerBlazor/AasxServerBlazor.csproj
+++ b/src/AasxServerBlazor/AasxServerBlazor.csproj
@@ -22,10 +22,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="HotChocolate.AspNetCore" Version="13.2.1"/>
+        <PackageReference Include="HotChocolate.AspNetCore" Version="13.9.6" />
         <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.6" />
         <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.5">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/AasxServerBlazor/AasxServerBlazor.csproj
+++ b/src/AasxServerBlazor/AasxServerBlazor.csproj
@@ -30,8 +30,8 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="ScottPlot" Version="4.1.68"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
-        <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0"/>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AasxServerBlazor/AasxServerBlazor.csproj
+++ b/src/AasxServerBlazor/AasxServerBlazor.csproj
@@ -23,7 +23,7 @@
 
     <ItemGroup>
         <PackageReference Include="HotChocolate.AspNetCore" Version="13.2.1"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.2"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.6" />
         <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.5">
             <PrivateAssets>all</PrivateAssets>

--- a/src/AasxServerBlazor/AasxServerBlazor.csproj
+++ b/src/AasxServerBlazor/AasxServerBlazor.csproj
@@ -29,7 +29,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="ScottPlot" Version="4.1.68"/>
+        <PackageReference Include="ScottPlot" Version="4.1.74" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
         <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.2" />
     </ItemGroup>

--- a/src/AasxServerDB/AasxServerDB.csproj
+++ b/src/AasxServerDB/AasxServerDB.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/AasxServerDB/AasxServerDB.csproj
+++ b/src/AasxServerDB/AasxServerDB.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.13.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AasxServerDB/AasxServerDB.csproj
+++ b/src/AasxServerDB/AasxServerDB.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AasxServerStandardBib/AasxServerStandardBib.csproj
+++ b/src/AasxServerStandardBib/AasxServerStandardBib.csproj
@@ -32,7 +32,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.34.0"/>
+        <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.6.2" />
         <PackageReference Include="MQTTnet.NETStandard" Version="3.0.8"/>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4"/>
@@ -42,7 +42,7 @@
         <PackageReference Include="SpookilySharp" Version="1.2.0"/>
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20371.2"/>
         <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0"/>
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.34.0"/>
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.6.2"/>
         <PackageReference Include="System.Security.Permissions" Version="6.0.0"/>
         <PackageReference Include="System.ServiceModel.Primitives" Version="8.0.0" />
     </ItemGroup>

--- a/src/AasxServerStandardBib/AasxServerStandardBib.csproj
+++ b/src/AasxServerStandardBib/AasxServerStandardBib.csproj
@@ -35,7 +35,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.6.2" />
         <PackageReference Include="MQTTnet.NETStandard" Version="3.0.8"/>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4"/>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
         <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.4.371.60"/>
         <PackageReference Include="QRCoder" Version="1.4.1"/>
         <PackageReference Include="ScottPlot" Version="4.1.74" />

--- a/src/AasxServerStandardBib/AasxServerStandardBib.csproj
+++ b/src/AasxServerStandardBib/AasxServerStandardBib.csproj
@@ -27,8 +27,8 @@
         <PackageReference Include="jose-jwt" Version="5.0.0" />
         <PackageReference Include="MailKit" Version="4.6.0" />
         <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.6" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.5">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.6" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/AasxServerStandardBib/AasxServerStandardBib.csproj
+++ b/src/AasxServerStandardBib/AasxServerStandardBib.csproj
@@ -38,7 +38,7 @@
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4"/>
         <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.4.371.60"/>
         <PackageReference Include="QRCoder" Version="1.4.1"/>
-        <PackageReference Include="ScottPlot" Version="4.1.68"/>
+        <PackageReference Include="ScottPlot" Version="4.1.74" />
         <PackageReference Include="SpookilySharp" Version="1.2.0"/>
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20371.2"/>
         <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0"/>

--- a/src/AasxServerStandardBib/AasxServerStandardBib.csproj
+++ b/src/AasxServerStandardBib/AasxServerStandardBib.csproj
@@ -43,7 +43,7 @@
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20371.2"/>
         <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0"/>
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.6.2"/>
-        <PackageReference Include="System.Security.Permissions" Version="6.0.0"/>
+        <PackageReference Include="System.Security.Permissions" Version="8.0.0" />
         <PackageReference Include="System.ServiceModel.Primitives" Version="8.0.0" />
     </ItemGroup>
 

--- a/src/AasxServerStandardBib/AasxServerStandardBib.csproj
+++ b/src/AasxServerStandardBib/AasxServerStandardBib.csproj
@@ -26,7 +26,7 @@
         <PackageReference Include="IdentityModel" Version="7.0.0" />
         <PackageReference Include="jose-jwt" Version="5.0.0" />
         <PackageReference Include="MailKit" Version="4.6.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.2"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.6" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.5">
             <PrivateAssets>all</PrivateAssets>

--- a/src/AasxServerStandardBib/AasxServerStandardBib.csproj
+++ b/src/AasxServerStandardBib/AasxServerStandardBib.csproj
@@ -23,9 +23,9 @@
 
     <ItemGroup>
         <PackageReference Include="Grapevine" Version="4.1.2"/>
-        <PackageReference Include="IdentityModel" Version="5.1.1"/>
-        <PackageReference Include="jose-jwt" Version="2.5.0"/>
-        <PackageReference Include="MailKit" Version="3.2.0"/>
+        <PackageReference Include="IdentityModel" Version="7.0.0" />
+        <PackageReference Include="jose-jwt" Version="5.0.0" />
+        <PackageReference Include="MailKit" Version="4.6.0" />
         <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.2"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.5">

--- a/src/AasxServerStandardBib/AasxServerStandardBib.csproj
+++ b/src/AasxServerStandardBib/AasxServerStandardBib.csproj
@@ -44,7 +44,7 @@
         <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0"/>
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.34.0"/>
         <PackageReference Include="System.Security.Permissions" Version="6.0.0"/>
-        <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.0"/>
+        <PackageReference Include="System.ServiceModel.Primitives" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AasxServerStandardBib/Credentials.cs
+++ b/src/AasxServerStandardBib/Credentials.cs
@@ -1,20 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net.Http.Headers;
 using System.Net.Http;
 using System.Text;
 using IdentityModel.Client;
 using IdentityModel;
 using Microsoft.IdentityModel.Tokens;
-using ScottPlot.Drawing.Colormaps;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Security.Claims;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
-using Org.BouncyCastle.Asn1.Ocsp;
-// using System.Drawing;
 
 namespace AasxServer
 {

--- a/src/IO.Swagger.Lib.V3/IO.Swagger.Lib.V3.csproj
+++ b/src/IO.Swagger.Lib.V3/IO.Swagger.Lib.V3.csproj
@@ -18,11 +18,11 @@
     <Using Include="AasCore.Aas3_0"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0"/>
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0"/>
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0"/>
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0"/>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.2" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.4"/>

--- a/src/IO.Swagger.Registry.Lib.V3/IO.Swagger.Registry.Lib.V3.csproj
+++ b/src/IO.Swagger.Registry.Lib.V3/IO.Swagger.Registry.Lib.V3.csproj
@@ -15,11 +15,11 @@
         <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0"/>
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0"/>
-        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0"/>
-        <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0"/>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.6.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.6.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.2" />
     </ItemGroup>
     <ItemGroup>
         <Using Include="AasCore.Aas3_0"/>


### PR DESCRIPTION
# Note
not all packages are valid with net8.0 and there are no current alternatives.

So far these are:

- GrapeVine
- QrCoder
- OPCFoundation.NetStandard.Opc.Ua