### PR TITLE
Fix the issue 333

### DIFF
--- a/src/IO.Swagger.Lib.V3/Exceptions/InvalidPaginationParameterException.cs
+++ b/src/IO.Swagger.Lib.V3/Exceptions/InvalidPaginationParameterException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace IO.Swagger.Lib.V3.Exceptions
+{
+    public class InvalidPaginationParameterException : Exception
+    {
+        public InvalidPaginationParameterException(string paramName, int? value) : base($"Invalid pagination parameter {paramName} value = {value}.")
+        {
+
+        }
+    }
+}

--- a/src/IO.Swagger.Lib.V3/Middleware/ExceptionMiddleware.cs
+++ b/src/IO.Swagger.Lib.V3/Middleware/ExceptionMiddleware.cs
@@ -88,6 +88,7 @@ namespace IO.Swagger.Lib.V3.Middleware
                         message.MessageType = MessageTypeEnum.Error;
                         break;
                     }
+                case InvalidPaginationParameterException:
                 case Jsonization.Exception:
                 case InvalidIdShortPathException:
                 case InvalidUpdateResourceException:

--- a/src/IO.Swagger.Lib.V3/Models/PaginationParameters.cs
+++ b/src/IO.Swagger.Lib.V3/Models/PaginationParameters.cs
@@ -1,4 +1,6 @@
-﻿namespace IO.Swagger.Models;
+namespace IO.Swagger.Models;
+
+using IO.Swagger.Lib.V3.Exceptions;
 
 public class PaginationParameters
 {
@@ -13,6 +15,10 @@ public class PaginationParameters
         _cursor = string.IsNullOrEmpty(cursor) || !int.TryParse(cursor, out var parsedCursor) ? 0 : parsedCursor;
         
         // Set limit to provided value or default to MaxResultSize
+        if(limit < 0)
+        {
+            throw new InvalidPaginationParameterException("Limit", limit);
+        }
         _limit = limit ?? MaxResultSize;
     }
 


### PR DESCRIPTION
# Description

This PR consists of fixes for issue with negative PaginationParameter "Limit".

## Motivation and Context
This change is required for the correct implementation of the APIs. With this fix, the server now returns "BadRequest" if a negative integer is provided as Limit.

Fixes # (issue)
#333 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
The fixes are tested manually with the help of in-buit swagger-ui and with aas-test-engine.

## Screenshots (if appropriate):

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
