### PR TITLE
Fix serialization of ServiceProfiles

### DIFF
--- a/src/IO.Swagger.Lib.V3/Converters/ServiceProfileEnumValueConverter.cs
+++ b/src/IO.Swagger.Lib.V3/Converters/ServiceProfileEnumValueConverter.cs
@@ -1,0 +1,51 @@
+namespace IO.Swagger.Lib.V3.Converters;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+public class ServiceProfileEnumValueConverter : JsonConverterFactory
+{
+    private readonly JsonStringEnumConverter baseConverter;
+    private readonly JsonNamingPolicy? namingPolicy;
+    public ServiceProfileEnumValueConverter()
+    {
+        this.baseConverter = new JsonStringEnumConverter();
+    }
+
+    public override bool CanConvert(Type typeToConvert) => baseConverter.CanConvert(typeToConvert);
+    public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        var query = from field in typeToConvert.GetFields(BindingFlags.Public | BindingFlags.Static)
+                    let attr = field.GetCustomAttribute<EnumMemberAttribute>()
+                    where attr != null && attr.Value != null
+                    select (field.Name, attr.Value);
+        var dictionary = query.ToDictionary(p => p.Item1, p => p.Item2);
+        if (dictionary.Count > 0)
+            return new JsonStringEnumConverter(new DictionaryLookupNamingPolicy(dictionary, namingPolicy)).CreateConverter(typeToConvert, options);
+        else
+            return baseConverter.CreateConverter(typeToConvert, options);
+    }
+
+
+}
+
+public class JsonNamingPolicyDecorator : JsonNamingPolicy
+{
+    readonly JsonNamingPolicy? underlyingNamingPolicy;
+
+    public JsonNamingPolicyDecorator(JsonNamingPolicy? underlyingNamingPolicy) => this.underlyingNamingPolicy = underlyingNamingPolicy;
+    public override string ConvertName(string name) => underlyingNamingPolicy?.ConvertName(name) ?? name;
+}
+
+internal class DictionaryLookupNamingPolicy : JsonNamingPolicyDecorator
+{
+    readonly Dictionary<string, string> dictionary;
+
+    public DictionaryLookupNamingPolicy(Dictionary<string, string> dictionary, JsonNamingPolicy? underlyingNamingPolicy) : base(underlyingNamingPolicy) => this.dictionary = dictionary ?? throw new ArgumentNullException();
+    public override string ConvertName(string name) => dictionary.TryGetValue(name, out var value) ? value : base.ConvertName(name);
+}

--- a/src/IO.Swagger.Lib.V3/Models/ServiceDescription.cs
+++ b/src/IO.Swagger.Lib.V3/Models/ServiceDescription.cs
@@ -16,6 +16,7 @@ using System.Runtime.Serialization;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using IO.Swagger.Lib.V3.Converters;
 
 namespace IO.Swagger.Models;
 
@@ -45,7 +46,8 @@ public partial class ServiceDescription : IEquatable<ServiceDescription>, IServi
                                                             {
                                                                 WriteIndented          = true,
                                                                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-                                                                Converters             = {new JsonStringEnumConverter()}
+                                                                //Converters             = {new JsonStringEnumConverter()}
+                                                                Converters             = {new ServiceProfileEnumValueConverter()}
                                                             };
 
 


### PR DESCRIPTION
# Description

This PR fixes the serialization issue w.r.t. ServiceProfiles in case of DescriptionAPI.

## Motivation and Context

The previous implementation used "JsonEnumStringConverter" in case of ServiceProfile serializations. However, this converter only takes EnumNames instead of numbers while serializing. However, the values provided by EnumMember attribute here are import. Thus, this PR provides a custom convert which takes values of the enums in serialization.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The issue and corresponding changes have tested manually with the help of swagger-ui.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/f3596a6c-6c43-40d5-ad6a-2609434d9a08)


# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
