### PR TITLE
Add constructor to ServiceDescription API

### DIFF
--- a/src/AasxServerBlazor/Configuration/ServerConfiguration.cs
+++ b/src/AasxServerBlazor/Configuration/ServerConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using AasSecurity;
@@ -233,7 +233,8 @@ public static class ServerConfiguration
                                                                                });
 
                                    swaggerGenOptions.EnableAnnotations();
-                                   swaggerGenOptions.CustomSchemaIds(type => type.FullName);
+                                   //Based on issue https://github.com/swagger-api/swagger-ui/issues/7911
+                                   swaggerGenOptions.CustomSchemaIds(type => type.FullName?.Replace("+", "."));
 
                                    var swaggerCommentedAssembly =
                                        typeof(AssetAdministrationShellRepositoryAPIApiController).Assembly.GetName().Name;

--- a/src/IO.Swagger.Lib.V3/Controllers/DescriptionAPIApi.cs
+++ b/src/IO.Swagger.Lib.V3/Controllers/DescriptionAPIApi.cs
@@ -25,6 +25,8 @@ public class DescriptionAPIApiController : ControllerBase
 {
     private readonly IServiceDescription _serviceDescription;
 
+    public DescriptionAPIApiController(IServiceDescription serviceDescription) => _serviceDescription = serviceDescription;
+
     /// <summary>
     /// Returns the self-describing information of a network resource (ServiceDescription)
     /// </summary>
@@ -41,7 +43,7 @@ public class DescriptionAPIApiController : ControllerBase
     public virtual IActionResult GetDescription()
     {
         var output = new ServiceDescription();
-        output.Profiles = new List<ServiceProfiles>
+        _serviceDescription.Profiles = new List<ServiceProfiles>
                                                     {
                                                         ServiceProfiles.AasxFileServerServiceSpecificationSSP001,
                                                         ServiceProfiles.SubmodelRepositoryServiceSpecificationSSP001,
@@ -53,6 +55,6 @@ public class DescriptionAPIApiController : ControllerBase
                                                         ServiceProfiles.ConceptDescriptionServiceSpecificationSSP001
                                                     };
         //return new ObjectResult(_serviceDescription.ToJson());
-        return new ObjectResult(output.ToJson());
+        return new ObjectResult(_serviceDescription.ToJson());
     }
 }


### PR DESCRIPTION
# Description

This PR adds a constructor based on IServiceDscription in the corresponding controller to fix the broken test pipeline.

## Motivation and Context

The unit tests written for Self-description API requires a injection of IServiceDescription in DescriptionAPIController. The injection was removed in earlier fix, therefore the tests no longer worked. Hence, bringing it back with this PR.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual testing, if the API works as expectation.

## Screenshots (if appropriate):

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
