### PR TITLE
Fix for \packages endpoint

### DIFF
--- a/src/IO.Swagger.Lib.V3/Controllers/AASXFileServerAPIApi.cs
+++ b/src/IO.Swagger.Lib.V3/Controllers/AASXFileServerAPIApi.cs
@@ -205,11 +205,10 @@ public class AASXFileServerAPIApiController : ControllerBase
     public virtual IActionResult GetAllAASXPackageIds([FromQuery] string? aasId, [FromQuery] int? limit, [FromQuery] string? cursor)
     {
         _logger.LogInformation($"Received request to get all the AASX packages.");
-        var decodedAasId = _decoderService.Decode("aasId", aasId);
-
-        if (decodedAasId == null)
+        string decodedAasId = null;
+        if (!string.IsNullOrEmpty(aasId))
         {
-            throw new NotAllowed($"Cannot proceed as {nameof(decodedAasId)} is null");
+            decodedAasId = _decoderService.Decode("aasId", aasId); 
         }
 
         var packages = _fileService.GetAllAASXPackageIds(decodedAasId);
@@ -217,7 +216,7 @@ public class AASXFileServerAPIApiController : ControllerBase
         var authResult = _authorizationService.AuthorizeAsync(User, packages, "SecurityPolicy").Result;
         if (!authResult.Succeeded)
         {
-            var failedReasons               = authResult.Failure.FailureReasons;
+            var failedReasons = authResult.Failure.FailureReasons;
             var authorizationFailureReasons = failedReasons.ToList();
             if (authorizationFailureReasons.Count != 0)
             {

--- a/src/IO.Swagger.Lib.V3/Formatters/AasResponseFormatter.cs
+++ b/src/IO.Swagger.Lib.V3/Formatters/AasResponseFormatter.cs
@@ -114,6 +114,10 @@ namespace IO.Swagger.Lib.V3.Formatters
             {
                 return base.CanWriteResult(context);
             }
+            if (typeof(PackageDescriptionPagedResult).IsAssignableFrom(context.ObjectType))
+            {
+                return base.CanWriteResult(context);
+            }
             else
                 return false;
         }
@@ -301,6 +305,22 @@ namespace IO.Swagger.Lib.V3.Formatters
                     pagingMetadata["cursor"] = cursor;
                 }
                 jsonNode["paging_metadata"] = pagingMetadata;
+                var writer = new Utf8JsonWriter(response.Body);
+                jsonNode.WriteTo(writer);
+                writer.FlushAsync().GetAwaiter().GetResult();
+            }
+            else if(typeof(PackageDescriptionPagedResult).IsAssignableFrom(context.ObjectType))
+            {
+                JsonNode jsonNode = null;
+                var options = new JsonSerializerOptions
+                {
+                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                };
+                if (context.Object is PackageDescriptionPagedResult pagedResult)
+                {
+                    jsonNode = JsonSerializer.SerializeToNode(pagedResult, options);
+                }
                 var writer = new Utf8JsonWriter(response.Body);
                 jsonNode.WriteTo(writer);
                 writer.FlushAsync().GetAwaiter().GetResult();

--- a/src/IO.Swagger.Lib.V3/Formatters/AasResponseFormatter.cs
+++ b/src/IO.Swagger.Lib.V3/Formatters/AasResponseFormatter.cs
@@ -324,6 +324,7 @@ namespace IO.Swagger.Lib.V3.Formatters
                 var writer = new Utf8JsonWriter(response.Body);
                 jsonNode.WriteTo(writer);
                 writer.FlushAsync().GetAwaiter().GetResult();
+                writer.Dispose();
             }
 
             return Task.FromResult(response);


### PR DESCRIPTION
# Description

Fixing the issue related to the API GetAllPackages from AASXFileServerInterface.

## Motivation and Context

This change fixes the broken GetAllPackages (\packages) operation from AASXFileServerInterface,

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manually and with AASX Package Explorer.

## Screenshots (if appropriate):

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
