### PR TITLE
Remove "aasIdentifier" from POST /submodels

### DIFF
--- a/src/AasxServerStandardBib/Interfaces/IAdminShellPackageEnvironmentService.cs
+++ b/src/AasxServerStandardBib/Interfaces/IAdminShellPackageEnvironmentService.cs
@@ -67,7 +67,7 @@ namespace AasxServerStandardBib.Interfaces
         
         bool            IsSubmodelPresent(string submodelIdentifier);
         bool            IsSubmodelPresent(string submodelIdentifier, out ISubmodel output, out int packageIndex);
-        ISubmodel       CreateSubmodel(ISubmodel newSubmodel, string aasIdentifier = null);
+        ISubmodel       CreateSubmodel(ISubmodel newSubmodel);
 
         #endregion
 

--- a/src/AasxServerStandardBib/Interfaces/ISubmodelService.cs
+++ b/src/AasxServerStandardBib/Interfaces/ISubmodelService.cs
@@ -18,7 +18,7 @@ namespace AasxServerStandardBib.Interfaces
 {
     public interface ISubmodelService
     {
-        ISubmodel              CreateSubmodel(ISubmodel newSubmodel, string aasIdentifier);
+        ISubmodel              CreateSubmodel(ISubmodel newSubmodel);
         ISubmodelElement       CreateSubmodelElement(string submodelIdentifier, ISubmodelElement newSubmodelElement, bool first);
         ISubmodelElement       CreateSubmodelElementByPath(string submodelIdentifier, string idShortPath, bool first, ISubmodelElement newSubmodelElement);
         void                   DeleteFileByPath(string submodelIdentifier, string idShortPath);

--- a/src/AasxServerStandardBib/Services/SubmodelService.cs
+++ b/src/AasxServerStandardBib/Services/SubmodelService.cs
@@ -528,18 +528,12 @@ namespace AasxServerStandardBib.Services
             return output;
         }
 
-        public ISubmodel CreateSubmodel(ISubmodel newSubmodel, string aasIdentifier)
+        public ISubmodel CreateSubmodel(ISubmodel newSubmodel)
         {
             //Verify the body first
             _verificationService.VerifyRequestBody(newSubmodel);
 
-            if (_packageEnvService.IsSubmodelPresent(newSubmodel.Id))
-            {
-                _logger.LogDebug($"Cannot create requested Submodel !!");
-                throw new DuplicateException($"Submodel with id {newSubmodel.Id} already exists.");
-            }
-
-            var output = _packageEnvService.CreateSubmodel(newSubmodel, aasIdentifier);
+            var output = _packageEnvService.CreateSubmodel(newSubmodel);
 
             return output;
         }

--- a/src/IO.Swagger.Lib.V3/Controllers/SubmodelRepositoryAPIApi.cs
+++ b/src/IO.Swagger.Lib.V3/Controllers/SubmodelRepositoryAPIApi.cs
@@ -2296,7 +2296,7 @@ public class SubmodelRepositoryAPIApiController : ControllerBase
     [SwaggerResponse(statusCode: 409, type: typeof(Result), description: "Conflict, a resource which shall be created exists already. Might be thrown if a Submodel or SubmodelElement with the same ShortId is contained in a POST request.")]
     [SwaggerResponse(statusCode: 500, type: typeof(Result), description: "Internal Server Error")]
     [SwaggerResponse(statusCode: 0, type: typeof(Result), description: "Default error handling for unmentioned status codes")]
-    public virtual IActionResult PostSubmodel([FromBody]Submodel body, [FromQuery] string aasIdentifier)
+    public virtual IActionResult PostSubmodel([FromBody]Submodel body)
     {
         if (body == null)
         {
@@ -2305,13 +2305,7 @@ public class SubmodelRepositoryAPIApiController : ControllerBase
 
         _logger.LogInformation($"Received request to create a submodel.");
 
-        var decodedAasIdentifier = _decoderService.Decode("aasIdentifier", aasIdentifier);
-        if (decodedAasIdentifier == null)
-        {
-            throw new NotAllowed($"Cannot proceed as {nameof(decodedAasIdentifier)} is null");
-        }
-
-        var output = _submodelService.CreateSubmodel(body, decodedAasIdentifier);
+        var output = _submodelService.CreateSubmodel(body);
 
         return CreatedAtAction("PostSubmodel", output);
     }


### PR DESCRIPTION
# Description

This PR removes the query parameter "aasIdentifier" from POST /submodels endpoint, so as to make it conformant with the specifications and make it interoperable with other solutions.

Fixes # (issue)
Fixes #369 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested manually with Swagger UI.

## Screenshots (if appropriate):

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
